### PR TITLE
Add training directly from language data

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ except:
 app = FastAPI()
 
 
-# These are the standard input features for the two endpoints 
+# These are the standard input features for the two endpoints
 # /train and /trainFromCASes.
 include_norm = [
     "_InitialView-Keyword-Overlap",
@@ -100,8 +100,7 @@ class ShortAnswerInstance(BaseModel):
 
 
 class TrainFromLanguageDataRequest(BaseModel):
-    # The instance dictionaries must be in ShortAnswerInstance format.
-    instances: List[Dict]
+    instances: List[ShortAnswerInstance]
     modelId: str
 
 
@@ -222,10 +221,8 @@ def trainFromCASes(req: TrainFromCASRequest):
 @app.post("/trainFromAnswers")
 def trainFromAnswers(req: TrainFromLanguageDataRequest):
     model_id = req.modelId
-    # The instance dictionaries are converted to ShortAnswerInstance objects.
-    instances = [ShortAnswerInstance(**instance) for instance in req.instances]
 
-    df = extract_features(instances)
+    df = extract_features(req.instances)
     include = list(df.columns)
 
     return do_training(df, model_id, include=include, dependent_variable=include[-1])

--- a/test_main.py
+++ b/test_main.py
@@ -6,6 +6,7 @@ import main
 
 from fastapi.testclient import TestClient
 from main import app
+from main import extract_features
 
 
 @pytest.fixture()
@@ -18,6 +19,37 @@ def xmi_bytes():
     with open("testdata/xmi/1ET5_7_0.xmi", "rb") as in_file:
         xmi_bytes = in_file.read()
     return xmi_bytes
+
+
+@pytest.fixture()
+def mock_instances():
+    instance1 = {
+        "taskId": "0",
+        "itemId": "0",
+        "itemPrompt": "mock_prompt",
+        "itemTargets": ["one", "two", "three"],
+        "learnerId": "0",
+        "answer": "two",
+    }
+    instance2 = {
+        "taskId": "1",
+        "itemId": "1",
+        "itemPrompt": "mock_prompt2",
+        "itemTargets": ["four", "five", "six"],
+        "learnerId": "1",
+        "answer": "two",
+    }
+    instance3 = {
+        "taskId": "2",
+        "itemId": "2",
+        "itemPrompt": "mock_prompt3",
+        "itemTargets": ["four", "five", "six"],
+        "learnerId": "2",
+        "answer": "five",
+    }
+
+    # The dicionaries are used to set up shortAnswerInstances.
+    return [instance1, instance2, instance3]
 
 
 def test_predict(client, xmi_bytes):
@@ -108,7 +140,7 @@ def test_addInstance_no_model_ID(client, xmi_bytes):
     )
 
 
-def test_train_from_CASes(client, xmi_bytes):
+def test_trainFromCASes(client, xmi_bytes):
     """
     Test the /train_from_CASes endpoint with test data.
 
@@ -122,7 +154,10 @@ def test_train_from_CASes(client, xmi_bytes):
     # This is not optimal because this makes this test depend on this endpoint
     # but this is the most natural way to populate the features dictionary.
     encoded_bytes = base64.b64encode(xmi_bytes)
-    instance_dict = {"modelId": "default_cas_test", "cas": encoded_bytes.decode("ascii")}
+    instance_dict = {
+        "modelId": "default_cas_test",
+        "cas": encoded_bytes.decode("ascii"),
+    }
     client.post("/addInstance", json=instance_dict)
     # Check that main.features has actually been populated.
     assert "default_cas_test" in main.features
@@ -132,7 +167,9 @@ def test_train_from_CASes(client, xmi_bytes):
     response = client.post("/trainFromCASes", json=instance_dict)
 
     # Store states to check whether the file and session object were created.
-    path_exists = os.path.exists(os.path.join(main.onnx_model_dir, "default_cas_test.onnx"))
+    path_exists = os.path.exists(
+        os.path.join(main.onnx_model_dir, "default_cas_test.onnx")
+    )
     session_stored = "default_cas_test" in main.inf_sessions
 
     # Change onnx model directory back and delete test file and inference
@@ -148,7 +185,7 @@ def test_train_from_CASes(client, xmi_bytes):
     assert session_stored
 
 
-def test_train_from_CASes_missing_CAS_instance(client):
+def test_trainFromCASes_missing_CAS_instance(client):
     """
     Test the /train_from_CASes endpoint with missing CAS instance.
 
@@ -169,7 +206,7 @@ def test_train_from_CASes_missing_CAS_instance(client):
     )
 
 
-def test_train_from_CASes_no_modelID(client):
+def test_trainFromCASes_no_modelID(client):
     """
     Test the /train_from_CASes endpoint with missing model ID.
 
@@ -220,3 +257,54 @@ def test_train(client):
     assert response.status_code == 200
     assert path_exists
     assert session_stored
+
+
+def test_trainFromAnswers(client, mock_instances):
+    """
+    Test the /trainFromAnswers endpoint.
+
+    :param client: A client for testing.
+    :param mock_instances: Mock short answer instances in dictonary
+    form.
+    """
+    # Change the onnx model directory for testing purposes.
+    main.onnx_model_dir = "testdata/train_data"
+
+    instance_dict = {
+        "instances": mock_instances,
+        "modelId": "random_data",
+    }
+    response = client.post("/trainFromAnswers", json=instance_dict)
+
+    # Store states to check whether the file and session object were created.
+    path_exists = os.path.exists(os.path.join(main.onnx_model_dir, "random_data.onnx"))
+    session_stored = "random_data" in main.inf_sessions
+
+    # Change onnx model directory back and delete test file and inference
+    # session object.
+    if session_stored:
+        del main.inf_sessions["random_data"]
+    if path_exists:
+        os.remove(os.path.join(main.onnx_model_dir, "random_data.onnx"))
+    main.onnx_model_dir = "onnx_models"
+
+    # The assertions are made after the clean-up process on the basis of the
+    # stored states. This ensures that cleaning is done in any case.
+    assert response.status_code == 200
+    assert path_exists
+    assert session_stored
+
+
+# Todo: This test must be changed once the dummy implementation
+#       has been replaced.
+def test_extract_features(mock_instances):
+    # The instance dictionaries are converted to ShortAnswerInstance objects.
+    instances = [main.ShortAnswerInstance(**instance) for instance in mock_instances]
+
+    features = extract_features(instances)
+
+    assert list(features["item_eq_answer"]) == [1, 0, 1]
+
+    # Test that the randomly generated values are either 0 or 1.
+    for outcome in features["outcome"]:
+        assert outcome in (0, 1)


### PR DESCRIPTION
- includes tests
- includes two new pydantic models
- parameters for do_training are configurable


There was one problem with the pydantic classes.
Classes cannot be send through the API because they are not json serializable.
Therefore, the TrainFromLanguageDataRequest class to does not accept  a list of ShortAnswerInstance objects.
To solve this problem I decided to have it accept a dictionary with all class variables.
This dictionary can then be passed to a ShortAnswerInstance in a next step.