### PR TITLE
Generalize feature extraction

### DIFF
--- a/main.py
+++ b/main.py
@@ -228,14 +228,14 @@ def trainFromAnswers(req: TrainFromLanguageDataRequest):
     # for ft_extractor in ft_extractors:
     #     df = pd.concat([df, ft_extractor.extract(req.instances)], axis=1)
 
-    include = list(df.columns)
     # Todo: Here the dependent variable is just the label of the first ShortAnswerInstance
     #       object. This is just temporary and must be changed for real implementation.
     dependent_variable = req.instances[0].label
 
-    # do_training does not accept an empty dataframe so this one serves as a dummy.
+    # Fixme: do_training does not accept an empty dataframe so this one serves as a dummy.
     # Todo: This line must be removed once real implementations exist.
-    df = pd.DataFrame([[1, 0], [1, 1], [0, 0]], columns=["item_eq_answer", "outcome"])
+    df = pd.DataFrame([[1, 0], [1, 1], [0, 0]], columns=["item_eq_answer", dependent_variable])
+    include = list(df.columns)
 
     return do_training(df, model_id, include=include, dependent_variable=dependent_variable)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.58.1
-numpy==1.16.3
+numpy==1.16.6
 pandas==0.24.2
 scikit-learn==0.20.3
 dkpro-cassis==0.2.9

--- a/test_main.py
+++ b/test_main.py
@@ -6,7 +6,6 @@ import main
 
 from fastapi.testclient import TestClient
 from main import app
-from main import extract_features
 
 
 @pytest.fixture()
@@ -30,6 +29,7 @@ def mock_instances():
         "itemTargets": ["one", "two", "three"],
         "learnerId": "0",
         "answer": "two",
+        "label": "0"
     }
     instance2 = {
         "taskId": "1",
@@ -38,6 +38,7 @@ def mock_instances():
         "itemTargets": ["four", "five", "six"],
         "learnerId": "1",
         "answer": "two",
+        "label": "0"
     }
     instance3 = {
         "taskId": "2",
@@ -46,9 +47,10 @@ def mock_instances():
         "itemTargets": ["four", "five", "six"],
         "learnerId": "2",
         "answer": "five",
+        "label": "1"
     }
 
-    # The dicionaries are used to set up shortAnswerInstances.
+    # The dicionaries are used to set up ShortAnswerInstance objects.
     return [instance1, instance2, instance3]
 
 
@@ -293,18 +295,3 @@ def test_trainFromAnswers(client, mock_instances):
     assert response.status_code == 200
     assert path_exists
     assert session_stored
-
-
-# Todo: This test must be changed once the dummy implementation
-#       has been replaced.
-def test_extract_features(mock_instances):
-    # The instance dictionaries are converted to ShortAnswerInstance objects.
-    instances = [main.ShortAnswerInstance(**instance) for instance in mock_instances]
-
-    features = extract_features(instances)
-
-    assert list(features["item_eq_answer"]) == [1, 0, 1]
-
-    # Test that the randomly generated values are either 0 or 1.
-    for outcome in features["outcome"]:
-        assert outcome in (0, 1)

--- a/test_main.py
+++ b/test_main.py
@@ -29,7 +29,7 @@ def mock_instances():
         "itemTargets": ["one", "two", "three"],
         "learnerId": "0",
         "answer": "two",
-        "label": "0"
+        "label": "outcome"
     }
     instance2 = {
         "taskId": "1",
@@ -38,7 +38,7 @@ def mock_instances():
         "itemTargets": ["four", "five", "six"],
         "learnerId": "1",
         "answer": "two",
-        "label": "0"
+        "label": "outcome"
     }
     instance3 = {
         "taskId": "2",
@@ -47,7 +47,7 @@ def mock_instances():
         "itemTargets": ["four", "five", "six"],
         "learnerId": "2",
         "answer": "five",
-        "label": "1"
+        "label": "outcome"
     }
 
     # The dicionaries are used to set up ShortAnswerInstance objects.


### PR DESCRIPTION
Here's my implementation of the generalization of the feature extraction.

Unfortunately, it was not possible to implement a real feature extraction on the basis of the abstract FeatureGroupExtractor class because 
1. abstract classes cannot be instantiated, so it is not possible to use its method either (because the method does not get an object assigned for its ```self``` attribute)
2. do_training does not work with an empty dataframe.

For this reason, to make the test work, I set up another dummy dataframe in trainFromAnswers.
Even though, there is no real feature extraction yet, everything should be set up for training once the child classes of FeatureGroupExtractor have been written and their extract methods return populated dataframes.