### PR TITLE
Exchange dummy for similarity extractor

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest==5.4.3
 requests
 skl2onnx==1.7.0
 onnxruntime==1.4.0
+textdistance==4.2.1

--- a/test_main.py
+++ b/test_main.py
@@ -29,7 +29,7 @@ def mock_instances():
         "itemTargets": ["one", "two", "three"],
         "learnerId": "0",
         "answer": "two",
-        "label": "outcome"
+        "label": "label1"
     }
     instance2 = {
         "taskId": "1",
@@ -38,7 +38,7 @@ def mock_instances():
         "itemTargets": ["four", "five", "six"],
         "learnerId": "1",
         "answer": "two",
-        "label": "outcome"
+        "label": "label1"
     }
     instance3 = {
         "taskId": "2",
@@ -47,7 +47,7 @@ def mock_instances():
         "itemTargets": ["four", "five", "six"],
         "learnerId": "2",
         "answer": "five",
-        "label": "outcome"
+        "label": "label2"
     }
 
     # The dicionaries are used to set up ShortAnswerInstance objects.
@@ -289,7 +289,6 @@ def test_trainFromAnswers(client, mock_instances):
     if path_exists:
         os.remove(os.path.join(main.onnx_model_dir, "random_data.onnx"))
     main.onnx_model_dir = "onnx_models"
-
     # The assertions are made after the clean-up process on the basis of the
     # stored states. This ensures that cleaning is done in any case.
     assert response.status_code == 200


### PR DESCRIPTION
I have adapted the function `trainFromAnswers()` to the SIMGroupExtractor.

There are some things that occurred to me:

1. Since the submodule `feature_extraction.py` now requires the library `textdistance`, I added it to the requirements.txt of this repository. It works. However, I think it would be a much better practice to create a `requirements.txt` in the submodule and then run both of them in the Docker container used for the isaac-ml-service.

This would only require to add the command `pip install -r features/requirements.txt` to the Dockerfile, I suppose (I'm never sure about how everything inside Docker works, so if this is wrong, please tell me).

2. I wasn't completely sure how to use the `ID` column in the dataframe. I understood that the `labels` variable from the `ShortAnswerInstance` object should be the data that goes into the y variable of the classifier as class labels so I added it inside the trainFromAnswers function.
At the moment the `ID` variable is used as a categorical variable in the training process and, therefore, converted to a one-hot representation. This should not be the expected behavior, right?
It looks to me as though Anna intended to use the `ID` variable as class label. 
If so, I think we should remove it because we already have labels.

3. When this occurred to me, I also discovered a bug in the `do_training()` function. Until now, all categorical features were converted to one-hot features, even if it was the class label.
Up to now this bug did not occur because the class label I used in the tests was always numeric.
That's why I moved the setup of the y dataframe some lines up in the function.
This way the class labels are taken out of the feature dataframe earlier and are not converted to one-hot representations.

4. It would maybe be good to test the functionality with a bit of actual data. At the moment I am only using my made-up data, which has nothing to do with the actual data. This way it would also be possible to not just test that the request is successful. 
Is it possible to get a small set of training instances for this?